### PR TITLE
Add sortable column headers to analytics tables

### DIFF
--- a/src/components/analytics/luck-streaks.tsx
+++ b/src/components/analytics/luck-streaks.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { SortableHeader } from '@/components/ui/sortable-header';
+import { useTableSort } from '@/lib/hooks/use-table-sort';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import type { LuckRecord, StreakRecord } from '@/lib/db/queries/analytics';
@@ -55,7 +57,31 @@ export function LuckStreaks({ luckRecords, streakRecords }: LuckStreaksProps) {
 	);
 }
 
+type LuckSortField = 'ownerName' | 'totalWins' | 'luckyWins' | 'unluckyLosses' | 'netLuck';
+
 function LuckAnalysis({ records }: { records: LuckRecord[] }) {
+	const compareFn = useCallback((a: LuckRecord, b: LuckRecord, field: LuckSortField) => {
+		switch (field) {
+			case 'ownerName':
+				return a.ownerName.toLowerCase().localeCompare(b.ownerName.toLowerCase());
+			case 'totalWins':
+				return a.totalWins - b.totalWins;
+			case 'luckyWins':
+				return a.luckyWins - b.luckyWins;
+			case 'unluckyLosses':
+				return a.unluckyLosses - b.unluckyLosses;
+			case 'netLuck':
+				return a.netLuck - b.netLuck;
+			default:
+				return 0;
+		}
+	}, []);
+
+	const { sortField, sortDirection, handleSort, sortedData } = useTableSort(records, compareFn, {
+		defaultField: 'netLuck' as LuckSortField,
+		textFields: ['ownerName' as LuckSortField],
+	});
+
 	return (
 		<Card>
 			<CardHeader>
@@ -70,15 +96,49 @@ function LuckAnalysis({ records }: { records: LuckRecord[] }) {
 				<Table>
 					<TableHeader>
 						<TableRow>
-							<TableHead>Owner</TableHead>
-							<TableHead className="text-center">Record</TableHead>
-							<TableHead className="text-center">Lucky Wins</TableHead>
-							<TableHead className="text-center">Unlucky Losses</TableHead>
-							<TableHead className="text-center">Net Luck</TableHead>
+							<SortableHeader field="ownerName" currentField={sortField} direction={sortDirection} onSort={handleSort}>
+								Owner
+							</SortableHeader>
+							<SortableHeader
+								field="totalWins"
+								currentField={sortField}
+								direction={sortDirection}
+								onSort={handleSort}
+								className="text-center"
+							>
+								Record
+							</SortableHeader>
+							<SortableHeader
+								field="luckyWins"
+								currentField={sortField}
+								direction={sortDirection}
+								onSort={handleSort}
+								className="text-center"
+							>
+								Lucky Wins
+							</SortableHeader>
+							<SortableHeader
+								field="unluckyLosses"
+								currentField={sortField}
+								direction={sortDirection}
+								onSort={handleSort}
+								className="text-center"
+							>
+								Unlucky Losses
+							</SortableHeader>
+							<SortableHeader
+								field="netLuck"
+								currentField={sortField}
+								direction={sortDirection}
+								onSort={handleSort}
+								className="text-center"
+							>
+								Net Luck
+							</SortableHeader>
 						</TableRow>
 					</TableHeader>
 					<TableBody>
-						{records.map((record) => (
+						{sortedData.map((record) => (
 							<TableRow key={record.ownerId}>
 								<TableCell className="font-medium">{record.ownerName}</TableCell>
 								<TableCell className="text-center font-mono">

--- a/src/components/ui/sortable-header.tsx
+++ b/src/components/ui/sortable-header.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
+import { TableHead } from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+
+export type SortDirection = 'asc' | 'desc';
+
+interface SortIconProps<F extends string> {
+	field: F;
+	currentField: F;
+	direction: SortDirection;
+}
+
+interface SortableHeaderProps<F extends string> {
+	field: F;
+	currentField: F;
+	direction: SortDirection;
+	onSort: (field: F) => void;
+	children: React.ReactNode;
+	className?: string;
+}
+
+export function SortIcon<F extends string>({ field, currentField, direction }: SortIconProps<F>) {
+	if (currentField !== field) {
+		return <ArrowUpDown className="ml-1 inline h-4 w-4 text-muted-foreground/50" />;
+	}
+	return direction === 'asc' ? (
+		<ArrowUp className="ml-1 inline h-4 w-4" />
+	) : (
+		<ArrowDown className="ml-1 inline h-4 w-4" />
+	);
+}
+
+export function SortableHeader<F extends string>({
+	field,
+	currentField,
+	direction,
+	onSort,
+	children,
+	className,
+}: SortableHeaderProps<F>) {
+	return (
+		<TableHead
+			className={cn('cursor-pointer select-none hover:bg-muted/50 transition-colors', className)}
+			onClick={() => onSort(field)}
+		>
+			<span className="flex items-center">
+				{children}
+				<SortIcon field={field} currentField={currentField} direction={direction} />
+			</span>
+		</TableHead>
+	);
+}

--- a/src/lib/hooks/use-table-sort.ts
+++ b/src/lib/hooks/use-table-sort.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import type { SortDirection } from '@/components/ui/sortable-header';
+
+export type { SortDirection };
+
+type CompareFn<T, F extends string> = (a: T, b: T, field: F) => number;
+
+interface UseTableSortOptions<F extends string> {
+	defaultField: F;
+	defaultDirection?: SortDirection;
+	textFields?: F[];
+}
+
+interface UseTableSortResult<T, F extends string> {
+	sortField: F;
+	sortDirection: SortDirection;
+	handleSort: (field: F) => void;
+	sortedData: T[];
+}
+
+/**
+ * Generic hook for table sorting.
+ *
+ * @param data - Array of data to sort
+ * @param compareFn - Function that compares two items. Should return:
+ *   - negative if a < b
+ *   - positive if a > b
+ *   - 0 if equal
+ *   The hook applies direction automatically by negating the result for descending order.
+ * @param options - Configuration options
+ * @returns Sort state and sorted data
+ *
+ * @example
+ * const { sortField, sortDirection, handleSort, sortedData } = useTableSort(
+ *   data,
+ *   (a, b, field) => {
+ *     switch (field) {
+ *       case 'name': return a.name.localeCompare(b.name);
+ *       case 'wins': return a.wins - b.wins;
+ *       default: return 0;
+ *     }
+ *   },
+ *   { defaultField: 'wins', textFields: ['name'] }
+ * );
+ */
+export function useTableSort<T, F extends string>(
+	data: T[],
+	compareFn: CompareFn<T, F>,
+	options: UseTableSortOptions<F>,
+): UseTableSortResult<T, F> {
+	const { defaultField, defaultDirection = 'desc', textFields = [] } = options;
+
+	const [sortField, setSortField] = useState<F>(defaultField);
+	const [sortDirection, setSortDirection] = useState<SortDirection>(defaultDirection);
+
+	const handleSort = (field: F) => {
+		if (sortField === field) {
+			setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+		} else {
+			setSortField(field);
+			// Default to ascending for text fields, descending for numeric
+			setSortDirection(textFields.includes(field) ? 'asc' : 'desc');
+		}
+	};
+
+	const sortedData = useMemo(() => {
+		return [...data].sort((a, b) => {
+			const result = compareFn(a, b, sortField);
+			return sortDirection === 'asc' ? result : -result;
+		});
+	}, [data, sortField, sortDirection, compareFn]);
+
+	return { sortField, sortDirection, handleSort, sortedData };
+}


### PR DESCRIPTION
## Summary
- Create shared sorting infrastructure (`SortableHeader` component + `useTableSort` hook)
- Add sortable columns to Playoff Leaderboard, Clutch Ratings, Hall of Fame Leaderboard, and Luck Analysis tables
- Refactor StandingsTable to use shared components for consistency

## Tables Updated
| Table | Sortable Columns |
|-------|------------------|
| Playoff Leaderboard | owner, apps, record, win%, titles, finals, 1st rd exits, avg score |
| Clutch Ratings | owner, playoff record, win% |
| Hall of Fame | owner, titles, last title, drought, sackos |
| Luck Analysis | owner, record, lucky wins, unlucky losses, net luck |

## Test plan
- [ ] Verify StandingsTable sorting still works as expected
- [ ] Test Playoff Leaderboard sorting on all columns
- [ ] Test Clutch Ratings sorting
- [ ] Test Hall of Fame Leaderboard sorting (including null handling for drought)
- [ ] Test Luck Analysis sorting
- [ ] Verify mobile views use sorted data

🤖 Generated with [Claude Code](https://claude.com/claude-code)